### PR TITLE
Update MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.61"
+          - "1.81"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.81"
 
 [features]
 default = ["std"]

--- a/convert.py
+++ b/convert.py
@@ -59,6 +59,8 @@ def emit_enum_entries(display, file):
             print(f"    /// {line}", file=file)
         if deprecated:
             print("    #[deprecated = \"marked as legacy in the spec, use Meta instead\"]", file=file)
+        if key == "Unidentified":
+            print("    #[default]", file=file)
         print(f"    {key},", file=file)
 
 
@@ -98,16 +100,15 @@ def convert_key(text, file):
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
+use core::error::Error;
 use core::fmt::{self, Display};
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 /// Key represents the meaning of a keypress.
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum NamedKey {""", file=file)
@@ -161,7 +162,6 @@ impl fmt::Display for UnrecognizedNamedKeyError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedNamedKeyError {}""", file=file)
 
 
@@ -172,10 +172,9 @@ def convert_code(text, file):
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
+use core::error::Error;
 use core::fmt::{self, Display};
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 /// Code is the physical position of a key.
 ///
@@ -185,7 +184,7 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-code/>
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Code {""", file=file)
@@ -281,7 +280,6 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}""", file=file)
 
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -4,10 +4,9 @@
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
+use core::error::Error;
 use core::fmt::{self, Display};
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 /// Code is the physical position of a key.
 ///
@@ -17,7 +16,7 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-code/>
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Code {
@@ -358,6 +357,7 @@ pub enum Code {
     Katakana,
     /// This value code should be used when no other
     /// value given in this specification is appropriate.
+    #[default]
     Unidentified,
     /// <kbd>F1</kbd>
     F1,
@@ -937,5 +937,4 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod webdriver;
 use serde::{Deserialize, Serialize};
 
 /// Describes the state a key is in.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyState {
     /// The key is pressed down.
@@ -41,6 +41,7 @@ pub enum KeyState {
     ///
     /// [keydown]: https://w3c.github.io/uievents/#event-type-keydown
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event
+    #[default]
     Down,
     /// The key is not pressed / was just released.
     ///
@@ -260,33 +261,9 @@ impl Key {
     }
 }
 
-impl Default for KeyState {
-    fn default() -> KeyState {
-        KeyState::Down
-    }
-}
-
 impl Default for Key {
     fn default() -> Self {
         Self::Named(NamedKey::default())
-    }
-}
-
-impl Default for NamedKey {
-    fn default() -> Self {
-        Self::Unidentified
-    }
-}
-
-impl Default for Code {
-    fn default() -> Code {
-        Code::Unidentified
-    }
-}
-
-impl Default for Location {
-    fn default() -> Location {
-        Location::Standard
     }
 }
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -5,7 +5,7 @@
 /// number keys can be above the letters or on the numpad. This enum allows differentiating them.
 ///
 /// See also [MDN's documentation](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location).
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Location {
     /// The key is in its "normal" location on the keyboard.
@@ -31,6 +31,7 @@ pub enum Location {
         env!("CARGO_PKG_VERSION"),
         "/source/docs/ATTRIBUTION.md",
     )]
+    #[default]
     Standard = 0x00,
 
     /// The key activated originated from the left key location (when there

--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -4,22 +4,22 @@
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
+use core::error::Error;
 use core::fmt::{self, Display};
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 /// Key represents the meaning of a keypress.
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum NamedKey {
     /// This key value is used when an implementation is unable to
     /// identify another key value, due to either hardware,
     /// platform, or software constraints.
+    #[default]
     Unidentified,
     /// The <kbd>Alt</kbd> (Alternative) key.<br/> This key enables the alternate modifier function for interpreting concurrent or subsequent keyboard input.<br/> This key value is also used for the Apple <kbd>Option</kbd> key.
     Alt,
@@ -1313,5 +1313,4 @@ impl fmt::Display for UnrecognizedNamedKeyError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedNamedKeyError {}


### PR DESCRIPTION
This also changes to use the derived `Default` for enums since that is available with a later MSRV (and would otherwise have clippy warnings).

Updating the MSRV allows the `no_std` support to be slightly better by allowing `core::error::Error` to be impl'd for the error types.