### PR TITLE
Add `#[doc(alias = ...)]` attributes

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -23,6 +23,8 @@ use std::error::Error;
 pub enum Code {
     /// <kbd>`~</kbd> on a US keyboard. This is the <kbd>半角/全角/漢字</kbd> (<span class="unicode">hankaku/zenkaku/kanji</span>) key on Japanese keyboards
     /// This is also called a backtick or grave.
+    #[doc(alias = "Backtick")]
+    #[doc(alias = "Grave")]
     Backquote,
     /// Used for both the US <kbd>\|</kbd> (on the 101-key layout) and also for the key
     /// located between the <kbd>"</kbd> and <kbd>Enter</kbd> keys on row C of the 102-,
@@ -131,6 +133,7 @@ pub enum Code {
     Period,
     /// <kbd>'"</kbd> on a US keyboard.
     /// This is also called an apostrophe.
+    #[doc(alias = "Apostrophe")]
     Quote,
     /// <kbd>;:</kbd> on a US keyboard.
     Semicolon,
@@ -153,12 +156,17 @@ pub enum Code {
     /// <kbd>Control</kbd> or <kbd>⌃</kbd>
     ControlRight,
     /// <kbd>Enter</kbd> or <kbd>↵</kbd>. Labelled <kbd>Return</kbd> on Apple keyboards.
+    #[doc(alias = "Return")]
     Enter,
     /// The Windows, <kbd>⌘</kbd>, <kbd>Command</kbd> or other OS symbol key.
     /// In Linux (XKB) terminology, this is often referred to as the left "Super".
+    #[doc(alias = "SuperLeft")]
+    #[doc(alias = "OSLeft")]
     MetaLeft,
     /// The Windows, <kbd>⌘</kbd>, <kbd>Command</kbd> or other OS symbol key.
     /// In Linux (XKB) terminology, this is often referred to as the right "Super".
+    #[doc(alias = "SuperRight")]
+    #[doc(alias = "OSRight")]
     MetaRight,
     /// <kbd>Shift</kbd> or <kbd>⇧</kbd>
     ShiftLeft,
@@ -313,6 +321,7 @@ pub enum Code {
     LaunchApp2,
     LaunchMail,
     MediaPlayPause,
+    #[doc(alias = "LaunchMediaPlayer")]
     MediaSelect,
     MediaStop,
     MediaTrackNext,
@@ -321,8 +330,11 @@ pub enum Code {
     /// replacing the <kbd>Eject</kbd> key.
     Power,
     Sleep,
+    #[doc(alias = "VolumeDown")]
     AudioVolumeDown,
+    #[doc(alias = "VolumeMute")]
     AudioVolumeMute,
+    #[doc(alias = "VolumeUp")]
     AudioVolumeUp,
     WakeUp,
     #[deprecated = "marked as legacy in the spec, use Meta instead"]

--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -42,6 +42,7 @@ pub enum NamedKey {
     /// The <kbd>Meta</kbd> key, to enable meta modifier function for interpreting concurrent or subsequent keyboard input.
     /// This key value is used for the <q>Windows Logo</q> key and the Apple <kbd>Command</kbd> or <kbd>⌘</kbd> key.
     /// In Linux (XKB) terminology, this is often referred to as "Super".
+    #[doc(alias = "Super")]
     Meta,
     /// The <kbd>NumLock</kbd> or Number Lock key, to toggle numpad mode function for interpreting subsequent keyboard input.
     NumLock,
@@ -60,6 +61,7 @@ pub enum NamedKey {
     #[deprecated = "marked as legacy in the spec, use Meta instead"]
     Super,
     /// The <kbd>Enter</kbd> or <kbd>↵</kbd> key, to activate current selection or accept current input.<br/> This key value is also used for the <kbd>Return</kbd> (Macintosh numpad) key.<br/> This key value is also used for the Android <code class="android">KEYCODE_DPAD_CENTER</code>.
+    #[doc(alias = "Return")]
     Enter,
     /// The Horizontal Tabulation <kbd>Tab</kbd> key.
     Tab,


### PR DESCRIPTION
For certain keys and codes where it makes sense, including those we already have alternatives for when parsing.

Fixes #64. Assumes that the meta->super change in https://github.com/pyfisch/keyboard-types/pull/68 will land.

It looks like this when searching:
<img width="479" alt="screenshot of searching for 'grave'" src="https://github.com/user-attachments/assets/43d57e63-9853-4b19-906f-6dad338c797e" />

But doesn't show up in the documentation otherwise (so https://github.com/pyfisch/keyboard-types/pull/68 is still valuable).