### PR TITLE
Release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyboard-types"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Pyfisch <pyfisch@posteo.org>"]
 description = "Contains types to define keyboard related events."
 readme = "README.md"


### PR DESCRIPTION
I believe that `keyboard-types` is usable by Winit now, so all that really remains is for us to make a new release.

Marked as a draft, because I believe the outstanding PRs should (ideally) be resolved first.