### PR TITLE
Raise MSRV to 1.81 on `no_std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         toolchain:
           - stable
           - "1.61"
+          - "1.81"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -19,9 +20,11 @@ jobs:
       # All features
       - run: cargo check --all-targets --all-features
       - run: cargo test --all-features
-      # No default features
-      - run: cargo check --all-targets --no-default-features
-      - run: cargo test --no-default-features
+      # No default features. Only works on Rust 1.81
+      - if: matrix.toolchain != 1.61
+        run: cargo check --all-targets --no-default-features
+      - if: matrix.toolchain != 1.61
+        run: cargo test --no-default-features
 
   clippy-fmt:
     name: Run Clippy and format code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
 edition = "2021"
+# 1.61 with `std` feature, 1.81 without.
 rust-version = "1.61"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ input in a cross-platform way.
 See also: [UI Events Specification](https://w3c.github.io/uievents/), and in
 particular [the section on keyboard events](https://w3c.github.io/uievents/#keys).
 
+Minimum Support Rust Version (MSRV)
+-----------------------------------
+
+The minimum supported Rust version is 1.61, or 1.81 if the `"std"` Cargo
+feature is disabled. This is not defined by policy, and may change at any time
+in a patch release.
+
 Updating Generated Code
 -----------------------
 

--- a/convert.py
+++ b/convert.py
@@ -100,6 +100,8 @@ def convert_key(text, file):
 
 use core::fmt::{self, Display};
 use core::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -161,7 +163,6 @@ impl fmt::Display for UnrecognizedNamedKeyError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedNamedKeyError {}""", file=file)
 
 
@@ -174,6 +175,8 @@ def convert_code(text, file):
 
 use core::fmt::{self, Display};
 use core::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -281,7 +284,6 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}""", file=file)
 
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -6,6 +6,8 @@
 
 use core::fmt::{self, Display};
 use core::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -937,5 +939,4 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}

--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -6,6 +6,8 @@
 
 use core::fmt::{self, Display};
 use core::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::error::Error;
 #[cfg(feature = "std")]
 use std::error::Error;
 
@@ -1313,5 +1315,4 @@ impl fmt::Display for UnrecognizedNamedKeyError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for UnrecognizedNamedKeyError {}


### PR DESCRIPTION
To get access to `core::error::Error`.

Alternative to https://github.com/rust-windowing/keyboard-types/pull/70.

Not sure how much I like it, I'd also be fine with doing nothing here. But I'd definitely rather do this than raise MSRV for everyone.