### PR TITLE
Add `impl From<NamedKey> for Key`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,12 @@ impl FromStr for Key {
     }
 }
 
+impl From<NamedKey> for Key {
+    fn from(value: NamedKey) -> Self {
+        Self::Named(value)
+    }
+}
+
 impl Key {
     /// Determine a *charCode* value for a key with a character value.
     ///
@@ -318,5 +324,10 @@ mod test {
         assert!(is_key_string("A"));
         assert!(!is_key_string("AA"));
         assert!(!is_key_string("	"));
+    }
+
+    #[test]
+    fn into() {
+        assert_eq!(Key::Named(NamedKey::Enter), NamedKey::Enter.into());
     }
 }


### PR DESCRIPTION
Part of https://github.com/rust-windowing/keyboard-types/issues/80.

This is a common pattern to allow more easily constructing "wrapper" enums like `Key` is. An example of this pattern is [`impl From<std::net::Ipv4Addr> for std::net::IpAddr`](https://doc.rust-lang.org/std/net/enum.IpAddr.html#impl-From%3CIpv4Addr%3E-for-IpAddr).