### PR TITLE
`impl From<NamedKey> for Key`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,12 @@ impl FromStr for Key {
     }
 }
 
+impl From<NamedKey> for Key {
+    fn from(value: NamedKey) -> Self {
+        Self::Named(value)
+    }
+}
+
 impl Key {
     /// Determine a *charCode* value for a key with a character value.
     ///


### PR DESCRIPTION
This is something I've wanted a few times in Masonry. It would help make event-creating code shorter.