### PR TITLE
Make it clear in the docs that space is not a named key

### DIFF
--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -15,6 +15,9 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
+///
+/// Note: "Space" is deliberately not a named key (to match the specification), use
+/// `Key::Character(" ")` instead.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]


### PR DESCRIPTION
This is a common point of confusion, see https://github.com/rust-windowing/keyboard-types/issues/82.