### PR TITLE
Release v0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyboard-types"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Pyfisch <pyfisch@posteo.org>"]
 description = "Contains types to define keyboard related events."
 readme = "README.md"


### PR DESCRIPTION
Only functional difference since v0.8.0 is https://github.com/rust-windowing/keyboard-types/pull/81, the rest is documentation improvements and nits.