### PR TITLE
Use `doc_cfg` instead of `doc_auto_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! input in a cross-platform way.
 
 #![warn(clippy::doc_markdown)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 extern crate alloc;


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/keyboard-types/issues/92.

Tested with:
```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --open --all-features
```